### PR TITLE
Raise commands timeout to 2 mins

### DIFF
--- a/collect_node_diag.sh
+++ b/collect_node_diag.sh
@@ -124,7 +124,7 @@ fi
 
 MAYBE_RUN_WITH_TIMEOUT=""
 if [ -n "$(command -v timeout)" ]; then
-    MAYBE_RUN_WITH_TIMEOUT="timeout --foreground 30"
+    MAYBE_RUN_WITH_TIMEOUT="timeout --foreground 120"
 fi
 
 function debug {


### PR DESCRIPTION
Dumping JMX metrics often takes longer than 30 seconds which gives us truncated json files in the collected artifacts.
Clusters with lots of tables will require more time as they get a lot more metrics.
Using a 2 minutes timeout seems reasonable to workaround the issue.