### PR TITLE
Add GHA workflow to perform integration tests

### DIFF
--- a/.github/workflows/oss_unencrypted.yml
+++ b/.github/workflows/oss_unencrypted.yml
@@ -1,0 +1,94 @@
+name: OSS ITs no encryption
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Compress the collector
+      run: |
+          tar czf diagnostic-collection.tar.gz ./*
+    - uses: webfactory/ssh-agent@v0.4.1
+      with:
+          ssh-private-key: ${{ secrets.TLP_CLUSTER_KEY }}
+    - name: Install dependencies
+      run: |
+          python -m venv venv
+          . venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install behave
+          sudo apt-get update
+          sudo apt-get install openjdk-8-jre -y
+          wget -O tlp-cluster.deb https://bintray.com/thelastpickle/tlp-tools-deb/download_file?file_path=tlp-cluster_0.6_all.deb
+          sudo dpkg -i tlp-cluster.deb
+          mkdir -p /home/runner/.tlp-cluster/profiles/default
+
+          sudo apt-get install     apt-transport-https     ca-certificates     curl     gnupg-agent     software-properties-common
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) \
+            stable"
+          sudo apt-get update
+          sudo apt-get install docker-ce docker-ce-cli containerd.io
+          sudo usermod -aG docker ${USER}
+    - name: Configure tlp-cluster
+      if: ${{ success() }}
+      env:
+        TLP_CLUSTER_KEY: ${{ secrets.TLP_CLUSTER_KEY }}
+        TLP_CLUSTER_SETTINGS: ${{ secrets.TLP_CLUSTER_SETTINGS }}
+      run: |
+          set -e
+          if [[ -n "${TLP_CLUSTER_KEY}" ]];
+          then
+            printf "%s" "${TLP_CLUSTER_SETTINGS}" > /home/runner/.tlp-cluster/profiles/default/settings.yaml
+            printf "%s" "${TLP_CLUSTER_KEY}" > /home/runner/.tlp-cluster/profiles/default/secret.pem
+          fi
+          chmod 600 /home/runner/.tlp-cluster/profiles/default/secret.pem
+
+    - name: Spin up cluster
+      if: ${{ success() }}
+      run: |
+          echo "Initializing AWS cluster..."
+          tlp-cluster init DS DSI-58 "Integration tests for the DS diagnostic toolkit" -c 3 --instance m5.large > /dev/null 2>&1
+          echo "Spinning up EC2 instances..."
+          tlp-cluster up --auto-approve > /dev/null 2>&1
+          tlp-cluster use 3.11.7 --config "cluster_name:diag_integration_tests" > /dev/null 2>&1
+          echo "Installing packages..."
+          tlp-cluster install > install.log 2>&1 || echo "meh... install phase seem to have failed"
+          echo "Starting Cassandra..."
+          tlp-cluster start > start.log 2>&1 || echo "meh... start phase seem to have failed"
+ 
+    - name: Run diagnostics collection
+      if: ${{ success() }}
+      run: |
+          shopt -s expand_aliases || setopt aliases
+          source env.sh
+          scp -F sshConfig diagnostic-collection.tar.gz cassandra0:/home/ubuntu
+          echo "Running the diagnostic collection..."
+          c0 "tar xvf diagnostic-collection.tar.gz && ./collect_diag.sh -t coss -r -m extended -u 900" > diag.log 2>&1
+          diag_tarball_path=$(grep "Complete diagnostics tarball is in" diag.log| cut -d'/' -f3)
+          diag_tarball_name=$(grep "Complete diagnostics tarball is in" diag.log| cut -d'/' -f4)
+          grep "Complete diagnostics tarball is in" diag.log
+          scp -F sshConfig cassandra0:/tmp/$diag_tarball_path/$diag_tarball_name .
+          tar xvf $diag_tarball_name > extract.log 2>&1
+          diag_directory=$(tail -1 extract.log | cut -d'/' -f1)
+          cd $diag_directory
+          full_diag_dir=$(pwd)
+          . ../venv/bin/activate
+          echo "Running checks..."
+          behave ../tests/integration/features -D artifacts-directory=$full_diag_dir
+    - name: Tear down
+      if: ${{ always() }}
+      run: |
+          echo "Terminating instances, please be patient..."
+          tlp-cluster down --auto-approve > down.log 2>&1
+          tail -10 down.log

--- a/generate_diag.sh
+++ b/generate_diag.sh
@@ -111,7 +111,7 @@ for i in "$DIAGS_DIR"/${PATTERN}-*.tar.gz; do
 done
 
 if [ -z "$INSIGHTS" ]; then # processing just DSE diagnostic
-    CLUSTER_NAME="$(cat -- */conf/cassandra/cassandra.yaml|grep -e '^cluster_name: '|sed -e "s|^cluster_name:[ ]*\(.*\)\$|\1|"|tr -d "'"|head -n 1|tr ' ' '_')"
+    CLUSTER_NAME=$(cat -- */conf/cassandra/cassandra.yaml|grep -e '^cluster_name: '|sed -e "s|^cluster_name:[ ]*\(.*\)\$|\1|"|tr -d "'"|head -n 1|tr ' ' '_'| tr '"' '_')
     COLLECT_DATE="$(date '+%Y-%m-%d_%H_%M_%S')"
     echo "Cluster name='$CLUSTER_NAME' collected at $COLLECT_DATE"
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration/features/__init__.py
+++ b/tests/integration/features/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration/features/environment.py
+++ b/tests/integration/features/environment.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+BEHAVE_DEBUG_ON_ERROR = True
+
+
+def setup_debug_on_error(userdata):
+    global BEHAVE_DEBUG_ON_ERROR
+    BEHAVE_DEBUG_ON_ERROR = userdata.getbool("BEHAVE_DEBUG_ON_ERROR")
+
+
+def before_all(context):
+    if "artifacts-directory" in context.config.userdata:
+        context.artifact_directory = context.config.userdata["artifacts-directory"]
+    if not context.config.log_capture:
+        logging.basicConfig(level=logging.DEBUG)
+    setup_debug_on_error(context.config.userdata)
+
+
+def after_step(context, step):
+    if BEHAVE_DEBUG_ON_ERROR and step.status == "failed":
+        # -- ENTER DEBUGGER: Zoom in on failure location.
+        # NOTE: Use IPython debugger, same for pdb (basic python debugger).
+        import ipdb
+        ipdb.post_mortem(step.exc_traceback)

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Feature: OSS Integration tests
+    Verify that the collected artifacts are showing the expected data
+    When the collection runs against Cassandra OSS without encryption nor auth
+
+    Scenario: Verify logs
+        Given artefacts are available in the configured artifacts directory
+        Then I can see the "system.log" file in the "logs/cassandra" subdirectory for each node
+        And I can see the "debug.log" file in the "logs/cassandra" subdirectory for each node
+
+    Scenario: Verify number of collected nodes
+        Given artefacts are available in the configured artifacts directory
+        Then 3 folders exist in the "nodes" subdirectory
+
+    Scenario: Verify the presence of jmx metrics
+        Given artefacts are available in the configured artifacts directory
+        Then 3 folders exist in the "nodes" subdirectory
+        And I can parse the metrics file in the first node subdirectory
+        And I can find the bean named "org.apache.cassandra.metrics:type=Table,keyspace=system,scope=batchlog,name=PendingFlushes" in the metrics file of the first node
+
+    Scenario: Verify the os related file
+        Given artefacts are available in the configured artifacts directory
+        Then I can verify the content of the "os-release" file for a random node
+        And I can verify the content of the "os-info.txt" file for a random node
+        And I can verify the content of the "process_limits" file for a random node
+        And I can verify the content of the "java_version.txt" file for a random node
+        And I can verify the content of the "java_cmdline" file for a random node

--- a/tests/integration/features/steps/__init__.py
+++ b/tests/integration/features/steps/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 DataStax Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import configparser
+import json
+import os
+import random
+
+from behave import given, when, then
+
+@given(r'artefacts are available in the configured artifacts directory')
+def _artefacts_are_available_in_the_configured_artifacts_directory(context):
+    assert os.path.isdir(context.artifact_directory)
+
+@then(u'{nb_folders} folders exist in the "{subfolder_name}" subdirectory')
+def _folders_exist_in_the_subdirectory(context, nb_folders, subfolder_name):
+    folders = get_nodes(context)
+    print("folders ({}): {}".format(len(folders), folders))
+
+    assert len(folders) == int(nb_folders)
+
+@then(u'I can see the "{expected_file}" file in the "{subdirectory}" subdirectory for each node')
+def _i_can_see_the_file_in_the_subdirectory_for_each_node(context, expected_file, subdirectory):
+    for folder in get_nodes(context):
+        assert os.path.isfile(os.path.join(context.artifact_directory, "nodes", folder, subdirectory, expected_file))
+
+@then(u'I can parse the metrics file in the first node subdirectory')
+def _i_can_parse_the_metrics_file(context):
+    _parse_metrics_file_of_the_first_node(context)
+
+@then(u'I can find the bean named "{bean_name}" in the metrics file of the first node')
+def _i_can_find_the_bean_named(context, bean_name):
+    json_metrics = _parse_metrics_file_of_the_first_node(context)    
+    for bean in json_metrics['beans']:
+        if bean["name"] == bean_name:
+            return
+    
+    print("Couldn't find the following bean in the metrics dump: {}".format(bean_name))
+    assert False
+
+@then(u'I can verify the content of the "{filename}" file for a random node')
+def _i_can_verify_the_content_of_the_file_for_a_random_node(context, filename):
+    if filename == "os-release":
+        verify_os_release(context)
+    elif filename == "os-info.txt":
+        verify_os_info(context)
+    elif filename == "debian_version":
+        verify_debian_version(context)
+    elif filename == "java_cmdline":
+        verify_java_cmdline(context)
+    elif filename == "java_version.txt":
+        verify_java_version(context)
+    elif filename == "process_limits":
+        verify_process_limits(context)
+
+def verify_os_release(context):
+    node = get_random_node_path(context)
+    parser = parse_config_file(os.path.join(context.artifact_directory, "nodes", node, "os-release"))
+    assert str(parser["DUMMY"]["NAME"]) == '"Ubuntu"'
+
+def verify_os_info(context):
+    node = get_random_node_path(context)
+    parser = parse_config_file(os.path.join(context.artifact_directory, "nodes", node, "os-info.txt"))
+    assert parser["DUMMY"]["kernel_name"] == "Linux"
+
+def verify_debian_version(context):
+    node = get_random_node_path(context)
+    with open(os.path.join(context.artifact_directory, "nodes", node, "debian_version")) as fp:
+        assert float(fp.read()) >= 9.0
+
+def verify_java_cmdline(context):
+    node = get_random_node_path(context)
+    with open(os.path.join(context.artifact_directory, "nodes", node, "java_cmdline")) as fp:
+        assert "org.apache.cassandra.service.CassandraDaemon" in fp.read()
+
+def verify_java_version(context):
+    node = get_random_node_path(context)
+    with open(os.path.join(context.artifact_directory, "nodes", node, "java_version.txt")) as fp:
+        assert "1.8.0" in fp.read()
+
+def verify_process_limits(context):
+    node = get_random_node_path(context)
+    with open(os.path.join(context.artifact_directory, "nodes", node, "process_limits")) as fp:
+        content = fp.read()
+        assert "Max open files" in content
+        assert "Max file locks" in content
+
+def get_nodes(context):
+    return list(filter(
+            lambda folder: not folder.startswith("."),
+            os.listdir(os.path.join(context.artifact_directory, "nodes"))
+        ))
+
+def get_first_node_path(context):
+    return get_nodes(context)[0]
+
+def get_random_node_path(context):
+    nodes = get_nodes(context)
+    return nodes[random.randint(0, len(nodes)-1)]
+
+def parse_config_file(filename):
+    with open(filename) as fp:
+        content = fp.read()
+        p = configparser.ConfigParser()
+        p.read_string("""
+        [DUMMY]
+        """ + content)
+        return p
+
+def _parse_metrics_file_of_the_first_node(context):
+    first_node_folder = get_first_node_path(context)
+    with open(os.path.join(context.artifact_directory, "nodes", first_node_folder, "jmx_dump.json"), 'r') as metrics_file:
+        return json.load(metrics_file)


### PR DESCRIPTION
The GitHub Actions workflow does the following things:
- spins up a 3 nodes cluster in AWS using OSS C* 3.11
- compresses and uploads the diagnostic collection tool to the first node
- runs the collection in extended mode
- downloads the generated tarball locally and decompresses it
- runs the test scenarios written using [Behave](https://behave.readthedocs.io/en/latest/) (Gherkin syntax)
- Tears down the cluster