### PR TITLE
Fix issues with DDAC installs

### DIFF
--- a/collect_diag.sh
+++ b/collect_diag.sh
@@ -112,7 +112,7 @@ DSE_DDAC_ROOT=""
 # Parse arguments
 # ---------------
 
-while getopts ":hzivrkn:c:d:f:o:p:s:t:u:I:m:e:S:K:T:B:P" opt; do
+while getopts ":hzivrkn:c:d:f:o:p:s:t:u:I:m:e:S:K:T:B:P:" opt; do
     case $opt in
         c) CQLSH_OPTS="$OPTARG"
            ;;
@@ -226,7 +226,7 @@ done
 declare -A pids
 for host in "${!servers[@]}"; do
     NODE_OUT_DIR="${servers[$host]}"
-    ssh $SSH_OPTS $host "bash --login ./collect_node_diag.sh -t $TYPE -o $NODE_OUT_DIR $COLLECT_OPTS $INSIGHT_COLLECT_OPTS -c '$CQLSH_OPTS' -n '$NT_OPTS' -d '$DT_OPTS' '$DSE_DDAC_ROOT'" &
+    ssh $SSH_OPTS $host "bash --login ./collect_node_diag.sh -t $TYPE -o $NODE_OUT_DIR $COLLECT_OPTS $INSIGHT_COLLECT_OPTS -c '$CQLSH_OPTS' -n '$NT_OPTS' -d '$DT_OPTS' -P '$DSE_DDAC_ROOT'" &
     pids[$host]="${!}"
 done
 

--- a/collect_node_diag.sh
+++ b/collect_node_diag.sh
@@ -26,7 +26,7 @@ function usage() {
     echo "   -m collection_mode - light, normal, extended. Default: normal"
     echo "   -v - verbose output"
     echo "   -z - don't execute commands that require sudo"
-    echo "   path - top directory of COSS, DDAC or DSE installation (for tarball installs)"
+    echo "   -P path - top directory of COSS, DDAC or DSE installation (for tarball installs)"
 }
 
 #echo "Got args $*"
@@ -66,12 +66,13 @@ DEFAULT_MCAC_DIR="/var/lib/cassandra/mcac_data/insights"
 MODE="normal"
 NOSUDO=""
 JMX_OPTS=""
+ROOT_DIR=""
 
 # ---------------
 # Parse arguments
 # ---------------
 
-while getopts ":hzivkn:c:p:f:d:o:t:I:m:" opt; do
+while getopts ":hzivkn:c:p:f:d:o:t:I:m:P:" opt; do
     case $opt in
         n) NT_OPTS="$OPTARG"
            ;;
@@ -104,6 +105,8 @@ while getopts ":hzivkn:c:p:f:d:o:t:I:m:" opt; do
            ;;
         v) VERBOSE=true
            ;;
+        P) ROOT_DIR="$OPTARG"
+           ;;
         h) usage
            exit 0
            ;;
@@ -114,7 +117,7 @@ while getopts ":hzivkn:c:p:f:d:o:t:I:m:" opt; do
     esac
 done
 shift "$((OPTIND -1))"
-ROOT_DIR="$1"
+
 
 mkdir -p "${OUTPUT_DIR}"
 


### PR DESCRIPTION
the `-P` argument was not correctly parsed due to a missing colon in the `collect_diag.sh` file.
I've also used the same flag for `collect_node_diag.sh` in order to have uniformity between the two scripts.