### PR TITLE
Make CI use pr_target event

### DIFF
--- a/.github/workflows/oss_unencrypted.yml
+++ b/.github/workflows/oss_unencrypted.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 jobs:
   integration-tests:


### PR DESCRIPTION
From [1], this allows running CI code from master, but use the commit from the PR, even if it's from a fork.
This way, Github feels safe exposing secrets to the CI (because the CI code is harder to compromise).

[1] https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/